### PR TITLE
Fix: Correct repository URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Check out the live demo of Flexbox Labs: [Demo](https://flexboxlabs.netlify.app/
 #### 1. Clone the repository
 
 ```shell
-git clone https://github.com/your-username/flexbox-labs.git
+git clone https://github.com/prazzon/flexbox-labs.git
 ```
 
 #### 2. Navigate to the app directory


### PR DESCRIPTION
The installation instructions in the README.md pointed to a placeholder repository URL (`git clone https://github.com/your-username/flexbox-labs.git`). This has been corrected to the actual repository URL: `git clone https://github.com/prazzon/Flexbox-Labs.git`.  This will allow users to successfully clone the project.
