### PR TITLE
Suggestion: Keep Shiny Text Animation Active on Hover for Improved UX

### DIFF
--- a/app/_components/UI/ShinyText/ShinyText.module.scss
+++ b/app/_components/UI/ShinyText/ShinyText.module.scss
@@ -12,10 +12,6 @@
    background-clip: text;
    display: inline-block;
    animation: shine 5s linear infinite;
-
-   &:hover {
-      animation: none;
-   }
    
    &.disabled {
       animation: none;


### PR DESCRIPTION
This is a small suggestion to improve the UX by keeping the Shiny Text animation always active, even when hovering over the text.  

Currently, the animation stops when the user hovers directly over the text, which might feel inconsistent as the button animation continues.  

I believe this change provides a smoother and more visually appealing experience. However, I understand that design decisions are subjective, and I respect your preferences.  

I've attached two short videos showing the behavior before and after this change for better context.  

Before:

https://github.com/user-attachments/assets/d1e89798-b73c-4baa-94fa-868dfca3abbb

After:

https://github.com/user-attachments/assets/6c9ad4b7-75b6-43f1-9e76-4998b8aa932e


Thanks for considering this suggestion! Let me know your thoughts.
