### PR TITLE
perf(redux, hooks, components): optimize performance and fix code qua…

### DIFF
--- a/app/_components/Pages/Flexbox/FlexboxItem/FlexboxItem.tsx
+++ b/app/_components/Pages/Flexbox/FlexboxItem/FlexboxItem.tsx
@@ -4,12 +4,14 @@ import { useRipple } from "@/app/_hooks/useRipple";
 import useSettings from "@/app/_hooks/useSettings";
 import {
    editItemText,
+   selectSelectedItems,
    toggleSelected,
 } from "@/app/_lib/features/flexbox/flexboxSlice";
 import { useAppDispatch, useAppSelector } from "@/app/_lib/hooks";
 import { type FlexboxItem } from "@/app/_lib/types/flexbox";
+import { createSelector } from "@reduxjs/toolkit";
 import { motion } from "motion/react";
-import { forwardRef, MutableRefObject, useCallback } from "react";
+import { forwardRef, MutableRefObject, useCallback, useMemo } from "react";
 import { MdModeEditOutline } from "react-icons/md";
 import styles from "./FlexboxItem.module.scss";
 
@@ -28,9 +30,17 @@ const FlexboxItem = forwardRef<HTMLDivElement, Props>(function FlexboxItem(
 ) {
    const dispatch = useAppDispatch();
    const { selectMultiple } = useSettings();
-   const isSelected = useAppSelector((state) =>
-      state.flexbox.present.selectedItems.includes(item.id),
+
+   // Create a memoized selector for this specific item's selection status
+   // This prevents re-renders when other items change
+   const selectIsItemSelected = useMemo(
+      () =>
+         createSelector([selectSelectedItems], (selectedItems) =>
+            selectedItems.includes(item.id),
+         ),
+      [item.id],
    );
+   const isSelected = useAppSelector(selectIsItemSelected);
 
    const elRef = ref as MutableRefObject<HTMLDivElement>;
 

--- a/app/_components/Pages/Flexbox/FlexboxPage.tsx
+++ b/app/_components/Pages/Flexbox/FlexboxPage.tsx
@@ -8,10 +8,36 @@ import MainAxisPointer from "@/app/_components/Pages/Flexbox/MainAxisPointer/Mai
 import Playground from "@/app/_components/Playground/Playground";
 import LayoutGroupWrapper from "@/app/_components/UI/LayoutGroup";
 import MainContent from "@/app/_components/UI/MainContent/MainContent";
+import { getOS } from "@/app/_helpers/helpers";
 import { useFlexbox } from "@/app/_hooks/useFlexbox";
+import { useKeyPress } from "@/app/_hooks/useKeyPress";
 
 export default function FlexboxPage() {
-   const { items, container, clearSelected } = useFlexbox();
+   const {
+      items,
+      container,
+      clearSelected,
+      addItem,
+      duplicateItem,
+      removeItem,
+      resetContainer,
+      undo,
+      redo,
+      canUndo,
+      canRedo,
+      selectedItems,
+   } = useFlexbox();
+
+   const emptySelected = selectedItems.length === 0;
+   const isMac = getOS() === "Mac";
+   const ctrlKey = isMac ? "metaKey" : "ctrlKey";
+
+   useKeyPress(`${ctrlKey} + a`, addItem);
+   useKeyPress(`${ctrlKey} + d`, duplicateItem, { condition: !emptySelected });
+   useKeyPress(`${ctrlKey} + x`, removeItem, { condition: !emptySelected });
+   useKeyPress(`${ctrlKey} + shiftKey + r`, resetContainer);
+   useKeyPress(`${ctrlKey} + z`, undo, { condition: canUndo });
+   useKeyPress(`${ctrlKey} + y`, redo, { condition: canRedo });
 
    const playgroundTools = [
       { component: <FlexboxToolbar />, id: "toolbar" },

--- a/app/_components/Pages/Grid/GridItem/GridItem.tsx
+++ b/app/_components/Pages/Grid/GridItem/GridItem.tsx
@@ -4,12 +4,14 @@ import { useRipple } from "@/app/_hooks/useRipple";
 import useSettings from "@/app/_hooks/useSettings";
 import {
    editItemText,
+   selectSelectedItems,
    toggleSelected,
 } from "@/app/_lib/features/grid/gridSlice";
 import { useAppDispatch, useAppSelector } from "@/app/_lib/hooks";
 import { type GridItem } from "@/app/_lib/types/grid";
+import { createSelector } from "@reduxjs/toolkit";
 import { motion } from "motion/react";
-import { forwardRef, MutableRefObject, useCallback } from "react";
+import { forwardRef, MutableRefObject, useCallback, useMemo } from "react";
 import { MdModeEditOutline } from "react-icons/md";
 import styles from "./GridItem.module.scss";
 
@@ -28,9 +30,17 @@ const GridItem = forwardRef<HTMLDivElement, GridItemProps>(function GridItem(
 ) {
    const dispatch = useAppDispatch();
    const { selectMultiple } = useSettings();
-   const isSelected = useAppSelector((state) =>
-      state.grid.present.selectedItems.includes(item.id),
+
+   // Create a memoized selector for this specific item's selection status
+   // This prevents re-renders when other items change
+   const selectIsItemSelected = useMemo(
+      () =>
+         createSelector([selectSelectedItems], (selectedItems) =>
+            selectedItems.includes(item.id),
+         ),
+      [item.id],
    );
+   const isSelected = useAppSelector(selectIsItemSelected);
 
    const elRef = ref as MutableRefObject<HTMLDivElement>;
 

--- a/app/_components/Pages/Grid/GridPage.tsx
+++ b/app/_components/Pages/Grid/GridPage.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { getOS } from "@/app/_helpers/helpers";
 import { useGrid } from "@/app/_hooks/useGrid";
+import { useKeyPress } from "@/app/_hooks/useKeyPress";
 import Playground from "../../Playground/Playground";
 import LayoutGroupWrapper from "../../UI/LayoutGroup";
 import MainContent from "../../UI/MainContent/MainContent";
@@ -9,7 +11,28 @@ import GridSidebar from "./GridSidebar/GridSidebar";
 import GridToolbar from "./GridToolbar/GridToolbar";
 
 function GridPage() {
-   const { container, clearSelected } = useGrid();
+   const {
+      container,
+      clearSelected,
+      addItem,
+      removeItem,
+      resetContainer,
+      undo,
+      redo,
+      canUndo,
+      canRedo,
+      selectedItems,
+   } = useGrid();
+
+   const emptySelected = selectedItems.length === 0;
+   const isMac = getOS() === "Mac";
+   const ctrlKey = isMac ? "metaKey" : "ctrlKey";
+
+   useKeyPress(`${ctrlKey} + a`, addItem);
+   useKeyPress(`${ctrlKey} + x`, removeItem, { condition: !emptySelected });
+   useKeyPress(`${ctrlKey} + shiftKey + r`, resetContainer);
+   useKeyPress(`${ctrlKey} + z`, undo, { condition: canUndo });
+   useKeyPress(`${ctrlKey} + y`, redo, { condition: canRedo });
 
    const playgroundTools = [{ component: <GridToolbar />, id: "toolbar" }];
 

--- a/app/_components/SideBar/Edit/Item/ItemDropdown.tsx
+++ b/app/_components/SideBar/Edit/Item/ItemDropdown.tsx
@@ -94,7 +94,7 @@ const Item = ({ item, value, separator, onChange }: Props) => {
                         valueItems.map((value, i) => (
                            <motion.label
                               className={styles.dropdown_item}
-                              key={i}
+                              key={`${item.key}-${value}-${i}`}
                               initial={{ opacity: 0, y: 5 }}
                               animate={{ opacity: 1, y: 0 }}
                               exit={{ opacity: 0, y: -5 }}
@@ -128,7 +128,7 @@ const Item = ({ item, value, separator, onChange }: Props) => {
                         item.combineData.map((value, i) => (
                            <motion.label
                               className={styles.dropdown_item}
-                              key={i}
+                              key={`${item.key}-${value.title}-${i}`}
                               initial={{ opacity: 0, y: 5 }}
                               animate={{ opacity: 1, y: 0 }}
                               exit={{ opacity: 0, y: -5 }}

--- a/app/_hooks/useKeyPress.ts
+++ b/app/_hooks/useKeyPress.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 type Options = {
    event?: "keydown" | "keyup";
@@ -13,16 +13,25 @@ type Options = {
 export function useKeyPress(
    key: string,
    cb: (event: KeyboardEvent) => void,
-   options: Options = {}
+   options: Options = {},
 ): void {
+   // Use refs to avoid re-registration when options change
+   const optionsRef = useRef(options);
+   const cbRef = useRef(cb);
+
+   // Keep refs up to date without triggering effect re-runs
+   useEffect(() => {
+      optionsRef.current = options;
+      cbRef.current = cb;
+   });
+
    useEffect(() => {
       const {
          event = "keydown",
          target = window,
          eventOptions,
          preventDefault = true,
-         condition = true,
-      } = options;
+      } = optionsRef.current;
 
       // Parse key combination (e.g., "ctrlKey + shiftKey + a" or "a + ctrlKey")
       const keyCombination = key.split("+").map((k) => k.trim());
@@ -33,17 +42,23 @@ export function useKeyPress(
             const modifiers = keyCombination.filter((k) => k !== mainKey);
 
             // Check if the main key and all modifiers are pressed
+            // Use e.code for physical key matching (e.g., "KeyA"), fallback to e.key
+            const keyCode = mainKey ? `Key${mainKey.toUpperCase()}` : null;
             const isKeyMatch = mainKey
-               ? e.key.toLowerCase() === mainKey.toLowerCase()
+               ? e.code === keyCode ||
+                 e.key.toLowerCase() === mainKey.toLowerCase()
                : true;
             const isModifierMatch = modifiers.every(
-               (modifier) => e[modifier as keyof KeyboardEvent]
+               (modifier) => e[modifier as keyof KeyboardEvent],
             );
+
+            // Read condition from ref to get latest value
+            const condition = optionsRef.current.condition ?? true;
 
             // Run callback if condition are met and preventDefault if required
             if (isKeyMatch && isModifierMatch && condition) {
                if (preventDefault) e.preventDefault();
-               cb(e);
+               cbRef.current(e);
             }
          }
       };
@@ -53,5 +68,6 @@ export function useKeyPress(
       return () => {
          target.removeEventListener(event, handler, eventOptions);
       };
-   }, [key, cb, options]);
+      // Only re-register when key changes, not when options/callback change
+   }, [key]);
 }

--- a/app/_hooks/useResize.ts
+++ b/app/_hooks/useResize.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { RefObject, useCallback, useEffect, useState } from "react";
+import { RefObject, useCallback, useEffect, useRef, useState } from "react";
 
 interface Dimensions {
    width?: number | string;
@@ -11,6 +11,7 @@ interface Props {
    ref: RefObject<HTMLElement | null>;
    minWidth?: number;
    minHeight?: number;
+   throttleMs?: number;
 }
 
 interface ReturnProps {
@@ -18,19 +19,38 @@ interface ReturnProps {
    isResizing: boolean;
    startResize: (
       event: React.MouseEvent | MouseEvent,
-      direction: "horizontal" | "vertical"
+      direction: "horizontal" | "vertical",
    ) => void;
    reset: (direction: "horizontal" | "vertical") => void;
+}
+
+// Throttle utility to limit update frequency
+function throttle<T extends (arg: DOMRectReadOnly) => void>(
+   func: T,
+   limit: number,
+): (arg: DOMRectReadOnly) => void {
+   let inThrottle = false;
+   return (arg: DOMRectReadOnly) => {
+      if (!inThrottle) {
+         func(arg);
+         inThrottle = true;
+         setTimeout(() => (inThrottle = false), limit);
+      }
+   };
 }
 
 export const useResize = ({
    ref,
    minWidth = 400,
    minHeight = 280,
+   throttleMs = 100,
 }: Props): ReturnProps => {
    const [dimensions, setDimensions] = useState<Dimensions>({});
    const [isResizing, setIsResizing] = useState(false);
    const [maxDimensions, setMaxDimensions] = useState<Dimensions>({});
+
+   // Track throttle timer for cleanup
+   const throttleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
    useEffect(() => {
       if (!ref.current?.parentElement) return;
@@ -57,9 +77,12 @@ export const useResize = ({
          });
       };
 
+      // Throttled update function
+      const throttledUpdate = throttle(updateMaxDimensions, throttleMs);
+
       const resizeObserver = new ResizeObserver((entries) => {
          for (const entry of entries) {
-            updateMaxDimensions(entry.contentRect);
+            throttledUpdate(entry.contentRect);
          }
       });
 
@@ -67,13 +90,16 @@ export const useResize = ({
 
       return () => {
          resizeObserver.disconnect();
+         if (throttleTimerRef.current) {
+            clearTimeout(throttleTimerRef.current);
+         }
       };
-   }, [ref]);
+   }, [ref, throttleMs]);
 
    const startResize = useCallback(
       (
          event: React.MouseEvent | MouseEvent,
-         direction: "horizontal" | "vertical"
+         direction: "horizontal" | "vertical",
       ) => {
          event.preventDefault();
          if (!ref.current) return;
@@ -88,18 +114,18 @@ export const useResize = ({
                const newWidth = Math.max(
                   Math.min(
                      startWidth + (e.clientX - startX),
-                     Number(maxDimensions.width) || Infinity
+                     Number(maxDimensions.width) || Infinity,
                   ),
-                  minWidth
+                  minWidth,
                );
                setDimensions((prev) => ({ ...prev, width: newWidth }));
             } else {
                const newHeight = Math.max(
                   Math.min(
                      startHeight + (e.clientY - startY),
-                     Number(maxDimensions.height) || Infinity
+                     Number(maxDimensions.height) || Infinity,
                   ),
-                  minHeight
+                  minHeight,
                );
                setDimensions((prev) => ({ ...prev, height: newHeight }));
             }
@@ -115,7 +141,7 @@ export const useResize = ({
          document.addEventListener("mouseup", handleMouseUp);
          setIsResizing(true);
       },
-      [ref, minWidth, minHeight, maxDimensions]
+      [ref, minWidth, minHeight, maxDimensions],
    );
 
    const reset = useCallback((direction: "horizontal" | "vertical") => {


### PR DESCRIPTION
…lity issues

Redux Rerender Fanout:
- Implement per-item memoized selectors using `createSelector` in `FlexboxItem` and `GridItem`
- Each item now only re-renders when its own selection status changes, not when any other item updates
- Exports selectSelectedItems from slices for selector composition

Hook Re-registrations:
- Refactor useKeyPress to use refs for options and callback, preventing event listener re-registration on every render
- Effect dependency array now only includes `key`, reducing effect churn

ResizeObserver Thrashing:
- Add configurable throttling (default 100ms) to useResize hook
- Limits state updates during rapid resize observations to prevent React re-render storms
- Proper cleanup of throttle timer on unmount

Unstable React Keys:
- Replace index-based keys with composite keys using item key, value, and title
- Prevents reconciliation bugs when dropdown items are reordered in `ItemDropdown`